### PR TITLE
Tests with stacks (and some other improvements)

### DIFF
--- a/src/stack/index.js
+++ b/src/stack/index.js
@@ -1,0 +1,53 @@
+function Stack() {
+  var that = this
+
+  that.stack = []
+
+  that.empty = function () {
+    // Tests if this stack is empty.
+    // Returns true if and only if this stack contains no items; false otherwise.
+    return !that.stack.length
+  }
+
+  that.peek = function () {
+    // Looks at the object at the top of this stack without removing it from the stack.
+    // Returns the object at the top of this stack.
+    // Throws: EmptyStackException - if this stack is empty.
+    throw_if_empty(that)
+    return that.stack[that.stack.length - 1]
+  }
+
+  that.pop = function (item) {
+    // Removes the object at the top of this stack and returns that object as the value of
+    //  this function.
+    // Returns the object at the top of this stack.
+    // Throws: EmptyStackException - if this stack is empty.
+    throw_if_empty(that)
+    return that.stack.pop(item)
+  }
+
+  that.push = function (item) {
+    // Pushes an item onto the top of this stack.
+    // Returns the item argument.
+    return that.stack.push(item)
+  }
+
+  // Private
+
+  function throw_if_empty() {
+    if (that.empty()) {
+      throw new EmptyStackException()
+    }
+  }
+
+  return that
+}
+
+// Private
+
+function EmptyStackException() {}
+
+module.exports = {
+  Stack: Stack,
+  EmptyStackException: EmptyStackException,
+}

--- a/src/stack/test.js
+++ b/src/stack/test.js
@@ -1,0 +1,79 @@
+const assert = require('../../test/utils/assert.js')
+const is = assert.is
+const is_exception = assert.is_exception
+
+const stack = require('.')
+const Stack = stack.Stack
+
+function before() {
+  return { stack: new Stack() }
+}
+
+function returns_true_when_empty(cfg) {
+  is(true, cfg.stack.empty())
+}
+
+function returns_false_when_not_empty(cfg) {
+  cfg.stack.push(1)
+  is(false, cfg.stack.empty())
+}
+
+function throws_on_empty_stack_peek(cfg) {
+  is_exception(stack.EmptyStackException, () => {
+    cfg.stack.peek()
+  })
+}
+
+function allows_peek_when_not_empty(cfg) {
+  var pushed = 1
+  cfg.stack.push(pushed)
+  is(pushed, cfg.stack.peek())
+}
+
+function peek_shows_correct_value(cfg) {
+  cfg.stack.push(1)
+  cfg.stack.push(2)
+  is(2, cfg.stack.peek())
+  cfg.stack.pop()
+  is(1, cfg.stack.peek())
+}
+
+function throws_on_empty_stack_pop(cfg) {
+  is_exception(stack.EmptyStackException, () => {
+    cfg.stack.pop()
+  })
+}
+
+function pop_returns_correct_value_and_updates_stack(cfg) {
+  var pushed = 1
+  cfg.stack.push(pushed)
+  is(pushed, cfg.stack.pop())
+  is(true, cfg.stack.empty())
+}
+
+function push_puts_correct_value_in_stack(cfg) {
+  var pushed
+  is(true, cfg.stack.empty())
+  pushed = 1
+  cfg.stack.push(pushed)
+  is(pushed, cfg.stack.peek())
+  pushed = 2
+  cfg.stack.push(pushed)
+  is(pushed, cfg.stack.peek())
+}
+
+module.exports = {
+  before: before,
+  all: () => {
+    return [
+      ['Returns true when stack is empty', returns_true_when_empty],
+      ['Returns false when stack is not empty', returns_false_when_not_empty],
+      ['Throws on empty stack .peek()', throws_on_empty_stack_peek],
+      ['Allows peek when not empty', allows_peek_when_not_empty],
+      ['Peek shows correct value', peek_shows_correct_value],
+      ['Throws on empty stack .pop()', throws_on_empty_stack_pop],
+      ['Pop works as expected and updates stack', pop_returns_correct_value_and_updates_stack],
+      ['Push works as expected and updates stack', push_puts_correct_value_in_stack],
+    ]
+  },
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,3 @@
 const test = require('./utils/common')
 
-test.all(['player'])
+test.all(['player', 'stack'])

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -15,6 +15,24 @@ function is(left, right) {
   }
 }
 
+function is_exception(exception, f) {
+  var is_exception = false
+  var e
+
+  try {
+    f()
+  } catch(e0) {
+    e = e0
+    if (e0 instanceof exception) {
+      is_exception = true
+    }
+  }
+
+  if (!is_exception) {
+    throw `got ${e}, expected ${exception.name}`
+  }
+}
+
 // Private
 
 function expect(left, right) {
@@ -28,5 +46,6 @@ function stringify(tuple) {
 }
 
 module.exports = {
-  is: is
+  is: is,
+  is_exception: is_exception
 }

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,6 +1,8 @@
 const style = require('../../test/utils/style.js')
 
 function all(under_test) {
+  console.log(style.white('Running tests...'))
+
   under_test.forEach(run_all)
   summary()
 }
@@ -15,33 +17,37 @@ function req(what) {
 }
 
 function run_all(what) {
-  console.log(style.white('Running tests...'))
-
   var tests = req(what)
   tests.all().forEach(
     ([test_name, test_fun]) => {
+      var cfg
+      var exc
+
       if (tests.before) {
-        tests.before()
+        cfg = tests.before()
       }
 
       var result
       var msg = "undefined"
 
       try {
-        test_fun_res = test_fun()
+        test_fun_res = test_fun(cfg)
         if (test_fun_res === undefined) {
           [result, msg] = this_passed()
         } else {
-          throw 'Tests should return either undefined or throw an exception'
+          exc = 'Tests should return either undefined or throw an exception'
+          throw exc
         }
-      } catch(e) {
+      } catch (e) {
         [result, msg] = this_failed(e)
+        exc = e.stack
       }
 
       if (result === false) {
         console.log()
         console.log(`Test [${what}] ${style.cyan(test_name)}`)
         console.log(style.red(`Failed: ${msg}`, {bold: true}))
+        console.log(exc)
       }
     }
   )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-enable -->

This adds a Stack implementation (as borrowed - API only) [from Java](https://docs.oracle.com/javase/8/docs/api/java/util/Stack.html).

It also improves a bit on the testing framework (yes, we don't need the `'ok'`, `'error'` tuples... that was for fun!):
* `before/0` can now return a configuration item to be passed to all tests that require it
* `assert.js:is_exception/2` is made available
* fixes a minor logging issue
* starts logging exceptions better!