### PR TITLE
Explore `after` as a sister to Common Test's `end_per_testcase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ where the test name is influenced by Elixir's `test "..." do ... end` macro.
 
 Similar to Common Test's `init_per_testcase` we explore the concept here via `before`.
 
+### `after`
+
+Similar to Common Test's `end_per_testcase` we explore the concept here via `after`.
+
 ### Summary
 
 A test summary will be similar to

--- a/src/stack/test.js
+++ b/src/stack/test.js
@@ -62,8 +62,13 @@ function push_puts_correct_value_in_stack(cfg) {
   is(pushed, cfg.stack.peek())
 }
 
+function after(cfg) {
+  is(true, cfg.stack instanceof Stack)
+}
+
 module.exports = {
   before: before,
+  after: after,
   all: () => {
     return [
       ['Returns true when stack is empty', returns_true_when_empty],

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -24,6 +24,7 @@ function run_all(what) {
       var exc
 
       if (tests.before) {
+        // Not expected to throw (!)
         cfg = tests.before()
       }
 
@@ -48,6 +49,11 @@ function run_all(what) {
         console.log(`Test [${what}] ${style.cyan(test_name)}`)
         console.log(style.red(`Failed: ${msg}`, {bold: true}))
         console.log(exc)
+      }
+
+      if (tests.after) {
+        // Not expected to throw (!)
+        tests.after(cfg)
       }
     }
   )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-enable -->
