### PR TITLE
Explore `before_all/after_all` as sisters to Common Test's `init_per_suite/end_per_suite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Similar to Common Test's `init_per_testcase` we explore the concept here via `be
 
 Similar to Common Test's `end_per_testcase` we explore the concept here via `after`.
 
+### `before_all`
+
+Similar to Common Test's `init_per_suite` we explore the concept here via `before_all`.
+
+### `after_all`
+
+Similar to Common Test's `end_per_suite` we explore the concept here via `after_all`.
+
 ### Summary
 
 A test summary will be similar to

--- a/src/stack/test.js
+++ b/src/stack/test.js
@@ -66,9 +66,22 @@ function after(cfg) {
   is(true, cfg.stack instanceof Stack)
 }
 
+function before_all() {
+  console.log()
+  console.log()
+  console.log('<stack_tests>')
+}
+
+function after_all() {
+  console.log()
+  process.stdout.write('</stack_tests>')
+}
+
 module.exports = {
   before: before,
   after: after,
+  before_all: before_all,
+  after_all: after_all,
   all: () => {
     return [
       ['Returns true when stack is empty', returns_true_when_empty],

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -18,6 +18,13 @@ function req(what) {
 
 function run_all(what) {
   var tests = req(what)
+  var cfg_all
+
+  if (tests.before_all) {
+    // Not expected to throw (!)
+    cfg_all = tests.before_all()
+  }
+
   tests.all().forEach(
     ([test_name, test_fun]) => {
       var cfg
@@ -25,7 +32,7 @@ function run_all(what) {
 
       if (tests.before) {
         // Not expected to throw (!)
-        cfg = tests.before()
+        cfg = tests.before(cfg_all)
       }
 
       var result
@@ -57,6 +64,11 @@ function run_all(what) {
       }
     }
   )
+
+  if (tests.after_all) {
+    // Not expected to throw (!)
+    tests.after_all()
+  }
 }
 
 function summary() {


### PR DESCRIPTION
... and we update `before/0` to accept the `cfg` returned by `before_all/0`.

<!-- markdownlint-disable MD041 -->
<!-- markdownlint-enable -->
