### PR TITLE
Add the concept of groups and configuration dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ exploring those). It is also possible (and handled) for functions to raise excep
 We mostly assume atoms as strings (in Erlang you can also write an atom as `'ok'`, so this ended
 up fitting rather nicely).
 
-### The Ok "tuple"
+### The Ok/error "tuples"
+
+#### The Ok "tuple"
 
 Similar to Erlang's `{:ok, <stuff>}` we introduce/explore this concept in this bit of code
 (check `src/utils/ok-error.js`), as `['ok', <stuff>]`. As a companion to this "tuple", we also
 consider the return `:ok` (Node.js `'ok'`) as valid.
 
-## The error "tuple"
+#### The error "tuple"
 
 The same as above where `:ok` becomes `:error`, and `'ok'` becomes `'error'`.
 
-## The special tagged `<stuff>`
+#### The special tagged `<stuff>`
 
 Because it's quite restrictive to not be able to classify `<stuff>` we also explore the "tagged
 tuple" with extra info, so there's special handling (internally) for return values like
@@ -59,50 +61,86 @@ add_new_no_config() ->
   ?assertEqual(ok, player:add(1)).
 ```
 
-### Common Test's `all/0`
+### Common Test similarities
+
+#### `all`
 
 It is expressed here as
 
 ```javascript
-  all: () => { return [
+  all: [
     ['Test description', fn]
-  ] }
+  ]
+```
+
+or simply
+
+```javascript
+  all: [
+    fn
+  ]
 ```
 
 where the test name is influenced by Elixir's `test "..." do ... end` macro.
 
-### `before`
+#### `before` (at the suite and group definition -level)
 
 Similar to Common Test's `init_per_testcase` we explore the concept here via `before`.
 
-### `after`
+The same applies to `init_per_group`.
+
+#### `after` (at the suite and group definition -level)
 
 Similar to Common Test's `end_per_testcase` we explore the concept here via `after`.
 
-### `before_all`
+The same applies to `end_per_group`.
+
+#### `before_all` (at the suite definition -level)
 
 Similar to Common Test's `init_per_suite` we explore the concept here via `before_all`.
 
-### `after_all`
+#### `after_all` (at the suite -level)
 
 Similar to Common Test's `end_per_suite` we explore the concept here via `after_all`.
 
-### Summary
+#### Groups
+
+Similar to Common Test's groups we allow `{group: 'name', all: [fn, ...]}` for group specific
+executions, where `fn` is expressed as in section `all`, above.
+
+#### Configuration dependencies
+
+Configuration for a suite is expected to start as `{}`, and run through `suite.before_all/1`
+(only runs once). At the end of the execution of a suite, the configuration is run through
+`suite.after_all/1` (again, only runs once).
+
+It gets picked up by:
+
+* `group.before/1`, in the context of a group
+* `suite.before/1`, in the context of a testcase
+
+If a testcase is inside a group, the flow is
+`suite.before_all/1 > group.before/1 > suite.before/1`, though.
+
+#### Skipping groups/testcases
+
+It is also possible to skip groups or testcases using object property `skip: true`. This will
+be reported in the test execution summary.
+
+#### Summary
 
 A test summary will be similar to
 
 ```shell
-Running tests...
-.
-Test [player] Adding a new player NOK - id missing
-Failed: got left = id_compulsor, right = id_compulsory
-..
+===> Running suites...
 
-Summary: 3 passed, 1 failed
-ERROR: not all tests passed!
+%%% suite player: .##..#.
+%%% suite stack: ........
+
+Failed 0 test(s). Passed 12 test(s). Skipped 3 test(s).
 ```
 
-inspired in both Erlang's and Elixir's output.
+inspired in both Erlang's (`rebar3` actually) and Elixir's output.
 
 ## Colored output
 

--- a/src/player/index.js
+++ b/src/player/index.js
@@ -13,7 +13,6 @@ function add(id, config) {
   }
 
   var checked_config_keys = check_config_keys(config)
-
   if (!error.is(checked_config_keys)) {
     players[id] = config
   }
@@ -23,8 +22,9 @@ function add(id, config) {
 
 // Caution!
 
-function __init_all() {
+function __init_all(cfg) {
   players = {}
+  return cfg
 }
 
 // Private
@@ -41,6 +41,7 @@ function check_config_key_type(key, config_key) {
   if (!assertion(config_key)) {
     return error._(['unexpected_key_type', key])
   }
+
   return ok._()
 }
 

--- a/src/player/test.js
+++ b/src/player/test.js
@@ -20,14 +20,28 @@ function add_new_config_nok() {
   is(error._(['unknown_key', 'dobi']), player.add(1, { dobi: 0 }))
 }
 
+function skipped1() {
+  // Should be skipped, so won't actually throw.
+  throw new Error()
+}
+
+function skipped2() {
+  // Should be skipped, so won't actually throw.
+  throw new Error()
+}
+
 module.exports = {
   before: player.__init_all,
-  all: () => {
-    return [
-      ['Adding a new player OK - no config', add_new_no_config],
-      ['Adding a new player NOK - id missing', add_new_id_missing],
-      ['Adding a new player OK - config OK', add_new_config_ok],
-      ['Adding a new player NOK - unknown key', add_new_config_nok],
-    ]
-  },
+  all: [
+    { name: 'Adding a new player OK - no config', fun: add_new_no_config },
+    {
+      group: true,
+      all: [skipped1, skipped2],
+      skip: true,
+    },
+    { name: 'Adding a new player NOK - id missing', fun: add_new_id_missing },
+    { name: 'Adding a new player OK - config OK', fun: add_new_config_ok },
+    { fun: skipped1, skip: true },
+    { name: 'Adding a new player NOK - unknown key', fun: add_new_config_nok },
+  ],
 }

--- a/src/stack/index.js
+++ b/src/stack/index.js
@@ -1,14 +1,11 @@
 function Stack() {
   var that = this
-
   that.stack = []
-
   that.empty = function () {
     // Tests if this stack is empty.
     // Returns true if and only if this stack contains no items; false otherwise.
     return !that.stack.length
   }
-
   that.peek = function () {
     // Looks at the object at the top of this stack without removing it from the stack.
     // Returns the object at the top of this stack.
@@ -16,7 +13,6 @@ function Stack() {
     throw_if_empty(that)
     return that.stack[that.stack.length - 1]
   }
-
   that.pop = function (item) {
     // Removes the object at the top of this stack and returns that object as the value of
     //  this function.
@@ -25,7 +21,6 @@ function Stack() {
     throw_if_empty(that)
     return that.stack.pop(item)
   }
-
   that.push = function (item) {
     // Pushes an item onto the top of this stack.
     // Returns the item argument.
@@ -45,7 +40,15 @@ function Stack() {
 
 // Private
 
-function EmptyStackException() {}
+function EmptyStackException() {
+  var that = this
+  that.name = 'EmptyStackException'
+  that.toString = function () {
+    return that.name
+  }
+
+  return that
+}
 
 module.exports = {
   Stack: Stack,

--- a/src/stack/test.js
+++ b/src/stack/test.js
@@ -4,9 +4,11 @@ const is_exception = assert.is_exception
 
 const stack = require('.')
 const Stack = stack.Stack
+const EmptyStackException = stack.EmptyStackException
 
-function before() {
-  return { stack: new Stack() }
+function before(cfg) {
+  cfg.stack = new Stack()
+  return cfg
 }
 
 function returns_true_when_empty(cfg) {
@@ -19,7 +21,7 @@ function returns_false_when_not_empty(cfg) {
 }
 
 function throws_on_empty_stack_peek(cfg) {
-  is_exception(stack.EmptyStackException, () => {
+  is_exception(EmptyStackException, () => {
     cfg.stack.peek()
   })
 }
@@ -39,7 +41,7 @@ function peek_shows_correct_value(cfg) {
 }
 
 function throws_on_empty_stack_pop(cfg) {
-  is_exception(stack.EmptyStackException, () => {
+  is_exception(EmptyStackException, () => {
     cfg.stack.pop()
   })
 }
@@ -52,9 +54,8 @@ function pop_returns_correct_value_and_updates_stack(cfg) {
 }
 
 function push_puts_correct_value_in_stack(cfg) {
-  var pushed
   is(true, cfg.stack.empty())
-  pushed = 1
+  var pushed = 1
   cfg.stack.push(pushed)
   is(pushed, cfg.stack.peek())
   pushed = 2
@@ -64,17 +65,15 @@ function push_puts_correct_value_in_stack(cfg) {
 
 function after(cfg) {
   is(true, cfg.stack instanceof Stack)
+  return cfg
 }
 
-function before_all() {
-  console.log()
-  console.log()
-  console.log('<stack_tests>')
+function before_all(cfg) {
+  return cfg
 }
 
-function after_all() {
-  console.log()
-  process.stdout.write('</stack_tests>')
+function after_all(cfg) {
+  return cfg
 }
 
 module.exports = {
@@ -82,16 +81,37 @@ module.exports = {
   after: after,
   before_all: before_all,
   after_all: after_all,
-  all: () => {
-    return [
-      ['Returns true when stack is empty', returns_true_when_empty],
-      ['Returns false when stack is not empty', returns_false_when_not_empty],
-      ['Throws on empty stack .peek()', throws_on_empty_stack_peek],
-      ['Allows peek when not empty', allows_peek_when_not_empty],
-      ['Peek shows correct value', peek_shows_correct_value],
-      ['Throws on empty stack .pop()', throws_on_empty_stack_pop],
-      ['Pop works as expected and updates stack', pop_returns_correct_value_and_updates_stack],
-      ['Push works as expected and updates stack', push_puts_correct_value_in_stack],
-    ]
-  },
+  all: [
+    {
+      group: '.empty',
+      all: [
+        { name: 'Returns true when stack is empty', fun: returns_true_when_empty },
+        { name: 'Returns false when stack is not empty', fun: returns_false_when_not_empty },
+      ],
+    },
+    {
+      group: '.peek',
+      all: [
+        { name: 'Throws on empty stack .peek()', fun: throws_on_empty_stack_peek },
+        { name: 'Allows peek when not empty', fun: allows_peek_when_not_empty },
+        { name: 'Peek shows correct value', fun: peek_shows_correct_value },
+      ],
+    },
+    {
+      group: '.pop',
+      all: [
+        throws_on_empty_stack_pop,
+        {
+          name: 'Pop works as expected and updates stack',
+          fun: pop_returns_correct_value_and_updates_stack,
+        },
+      ],
+    },
+    {
+      group: '.push',
+      all: [
+        { name: 'Push works as expected and updates stack', fun: push_puts_correct_value_in_stack },
+      ],
+    },
+  ],
 }

--- a/test/utils/assert.js
+++ b/test/utils/assert.js
@@ -1,5 +1,6 @@
 const ok = require('../../src/ok.js')
 const error = require('../../src/error.js')
+const style = require('./style')
 
 function is(left, right) {
   if (ok.is_typed(left) && ok.is_typed(right)) {
@@ -18,7 +19,6 @@ function is(left, right) {
 function is_exception(exception, f) {
   var is_exception = false
   var e
-
   try {
     f()
   } catch(e0) {
@@ -29,7 +29,7 @@ function is_exception(exception, f) {
   }
 
   if (!is_exception) {
-    throw `got ${e}, expected ${exception.name}`
+    throw new Error(`got ${e}, expected ${exception.name}`)
   }
 }
 
@@ -37,7 +37,7 @@ function is_exception(exception, f) {
 
 function expect(left, right) {
   if (left !== right) {
-    throw `got left = ${left}, right = ${right}`
+    throw new Error(`got ${style.red(right, {bold: true})}, expected ${style.red(left)}`)
   }
 }
 

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,9 +1,10 @@
 const style = require('../../test/utils/style.js')
 
 function all(under_test) {
-  console.log(style.white('Running tests...'))
+  console.log(style.green('===> Running suites...'))
+  console.log()
 
-  under_test.forEach(run_all)
+  under_test.forEach(run_suite)
   summary()
 }
 
@@ -11,92 +12,177 @@ function all(under_test) {
 
 var passed = 0
 var failed = 0
+var skipped = 0
 
-function req(what) {
-  return require(`../../src/${what}/test.js`)
+function req(suite_name) {
+  return require(`../../src/${suite_name}/test.js`)
 }
 
-function run_all(what) {
-  var tests = req(what)
-  var cfg_all
+function run_suite(suite_name) {
+  process.stdout.write(`%%% suite ${suite_name}: `)
 
-  if (tests.before_all) {
+  var suite = req(suite_name)
+  var suite_cfg = {}
+  if (suite.before_all) {
     // Not expected to throw (!)
-    cfg_all = tests.before_all()
+    suite_cfg = suite.before_all(suite_cfg)
   }
 
-  tests.all().forEach(
-    ([test_name, test_fun]) => {
-      var cfg
-      var exc
+  suite.all.forEach(
+    (group_or_testcase) => {
+      var testcase_cfg = suite_cfg
 
-      if (tests.before) {
-        // Not expected to throw (!)
-        cfg = tests.before(cfg_all)
-      }
-
-      var result
-      var msg = "undefined"
-
-      try {
-        test_fun_res = test_fun(cfg)
-        if (test_fun_res === undefined) {
-          [result, msg] = this_passed()
-        } else {
-          exc = 'Tests should return either undefined or throw an exception'
-          throw exc
-        }
-      } catch (e) {
-        [result, msg] = this_failed(e)
-        exc = e.stack
-      }
-
-      if (result === false) {
-        console.log()
-        console.log(`Test [${what}] ${style.cyan(test_name)}`)
-        console.log(style.red(`Failed: ${msg}`, {bold: true}))
-        console.log(exc)
-      }
-
-      if (tests.after) {
-        // Not expected to throw (!)
-        tests.after(cfg)
+      if (group_or_testcase.group !== undefined) {
+        var group = group_or_testcase
+        var group_cfg = suite_cfg
+        run_group(group, group_cfg, suite, suite_name)
+      } else {
+        var testcase = group_or_testcase
+        var testcase_cfg = suite_cfg
+        run_testcase(testcase, testcase_cfg, suite, suite_name)
       }
     }
   )
 
-  if (tests.after_all) {
+  if (suite.after_all) {
     // Not expected to throw (!)
-    tests.after_all()
+    suite.after_all(suite_cfg)
+  }
+
+  console.log()
+}
+
+function run_group(group, group_cfg, suite, suite_name) {
+  var skipped = group.skip
+  if (!skipped) {
+    if (group.before) {
+      group_cfg = group.before(group_cfg)
+    }
+
+    group.all.forEach(
+      (testcase) => {
+        var testcase_cfg = group_cfg
+        run_testcase(testcase, testcase_cfg, suite, suite_name)
+      }
+    )
+
+    if (group.before) {
+      group.before(group_cfg)
+    }
+  } else {
+    this_skipped(group.all.length)
+  }
+}
+
+function run_testcase(testcase, testcase_cfg, suite, suite_name) {
+  if (suite.before) {
+    // Not expected to throw (!)
+    testcase_cfg = suite.before(testcase_cfg)
+  }
+
+  var test_fun
+  if (testcase.fun) {
+    test_fun = testcase.fun
+  } else {
+    test_fun = testcase
+  }
+
+  var test_name
+  if (testcase.name) {
+    test_name = testcase.name
+  } else {
+    test_name = test_fun.name
+  }
+
+  var exc
+  var result
+  var msg
+  if (!testcase.skip) {
+    try {
+      test_fun_res = test_fun(testcase_cfg)
+      if (test_fun_res === undefined) {
+        [result, msg] = this_passed()
+      } else {
+        exc = 'Tests should return either undefined or throw an exception'
+        throw exc
+      }
+    } catch (e) {
+      [result, msg] = this_failed(e)
+      exc = e.stack
+    }
+  } else {
+    [result, msg] = this_skipped(1)
+  }
+
+  if (result === false) {
+    console.log()
+    console.log(`%%% suite ${suite_name} ==> ${test_name}: ${style.red('FAILED')}`)
+    if (exc) {
+      console.log(`%%% suite ${suite_name} ==> ${test_name}: ${exc}`)
+    } else {
+      console.log(`%%% suite ${suite_name} ==> ${test_name}: ${msg}`)
+    }
+  }
+
+  if (suite.after) {
+    // Not expected to throw (!)
+    suite.after(testcase_cfg)
   }
 }
 
 function summary() {
   console.log()
-  console.log()
+
   var styled_failed = failed
   if (failed) {
-    styled_failed = style.red(failed, {bold: true})
+    styled_failed = style.red(failed)
   }
+
   var styled_passed = passed
   if (passed) {
-    styled_passed = style.green(passed, {bold: true})
+    styled_passed = style.green(passed)
   }
-  console.log(`${style.white('Summary')}: ${styled_passed} passed, ${styled_failed} failed`)
+
+  process.stdout.write(`Failed ${styled_failed} test(s). Passed ${styled_passed} test(s).`)
+
+  if (skipped) {
+    skipped = ` Skipped ${skipped} test(s).`
+  } else {
+    skipped = ""
+  }
+
+  console.log(skipped)
+
   if (failed) {
-    console.log(style.red('ERROR: not all tests passed!', {bold: true}))
+    var failures_occurred = style.red(`Failures occurred running tests: ${failed}`, {bold: true})
+    console.log(`${style.red('===>')} ${failures_occurred}`)
   }
 }
 
 function this_passed() {
   passed += 1
-  process.stdout.write(style.green('.', {bold: true}))
-  return [true, '.']
+
+  var dot = style.green('.')
+  process.stdout.write(dot)
+
+  return [true, dot]
 }
 
 function this_failed(e) {
   failed += 1
+
   return [false, e]
+}
+
+function this_skipped(how_many) {
+  skipped += how_many
+
+  var ast = '#'
+  while(how_many-- > 0) {
+    process.stdout.write(ast)
+  }
+
+  return [true, ast]
 }
 
 module.exports = {


### PR DESCRIPTION
We also introduce a few other tweaks/niceties:

* skippable groups and testcases
* improved documentation
* "Summary" made closer to `rebar3`'s
* testcases now don't need to be expressed as `[<desc>, <fn>]`, but just `<fn>`
* improved exception -based assertions and outputs, upon failure

<!-- markdownlint-disable MD041 -->
<!-- markdownlint-enable -->
