### PR TITLE
Split `all` interface into "suite name" and "suite config."

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodejs-tests",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodejs-tests",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "eslint": "9.7.0",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "yamllint": "npm run yamllint-github && npm run yamllint-yml",
     "dist": "npm install && npm run prettier && npm run eslint && npm run markdownlint && npm run yamllint && node test"
   },
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,6 @@
 const test = require('./utils/common')
 
-test.all(['player', 'stack'])
+test.all([
+  ['player', require('../src/player/test.js')],
+  ['stack', require('../src/stack/test.js')]
+])

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -14,14 +14,14 @@ var passed = 0
 var failed = 0
 var skipped = 0
 
-function req(suite_name) {
-  return require(`../../src/${suite_name}/test.js`)
+function req(suite_name_suite) {
+  return suite_name_suite
 }
 
-function run_suite(suite_name) {
+function run_suite(suite_name_suite) {
+  var [suite_name, suite] = req(suite_name_suite)
   process.stdout.write(`%%% suite ${suite_name}: `)
 
-  var suite = req(suite_name)
   var suite_cfg = {}
   if (suite.before_all) {
     // Not expected to throw (!)


### PR DESCRIPTION
We were assuming suites in `../../src/<etc.>` and this is no good!

While the new approach may seem a little more complex it's also much more generic

```javascript
all([
    [<suite_name>, <suite_cfg>],
    ...
])
```

<!-- markdownlint-disable MD041 -->
<!-- markdownlint-enable -->
